### PR TITLE
README and testcases update for MaxLen and Approx options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ stream.Add(ctx, Event{
 })
 ```
 The Options.TTL parameter will evict stream entries after the specified duration has elapsed (or it can be set to `NoExpiration`).
-The Options.MaxLen parameter will older stream entries to accommodate newer entries after the maximum number of entries is reached.
+The Options.MaxLen parameter will remove older stream entries to accommodate newer entries after the maximum number of entries is reached.
 
 #### Metadata
 

--- a/README.md
+++ b/README.md
@@ -109,13 +109,14 @@ errors.Is(msg.Err, errMyTypeFailedToParse)
 Streams are simple wrappers for basic redis commands on a stream.
 
 ```go
-stream := NewStream[Event](rdb, "my-stream", &Options{TTL: time.Hour})
+stream := NewStream[Event](rdb, "my-stream", &Options{TTL: time.Hour, MaxLen: 1000})
 stream.Add(ctx, Event{
   Kind:     "Example event",
   Priority: 1,
 })
 ```
 The Options.TTL parameter will evict stream entries after the specified duration has elapsed (or it can be set to `NoExpiration`).
+The Options.MaxLen parameter will older stream entries to accommodate newer entries after the maximum number of entries is reached.
 
 #### Metadata
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ errors.Is(msg.Err, errMyTypeFailedToParse)
 Streams are simple wrappers for basic redis commands on a stream.
 
 ```go
-stream := NewStream[Event](rdb, "my-stream", &Options{TTL: time.Hour, MaxLen: 1000})
+stream := NewStream[Event](rdb, "my-stream", &Options{TTL: time.Hour, MaxLen: 1000, Approx: true})
 stream.Add(ctx, Event{
   Kind:     "Example event",
   Priority: 1,
@@ -117,7 +117,7 @@ stream.Add(ctx, Event{
 ```
 The Options.TTL parameter will evict stream entries after the specified duration has elapsed (or it can be set to `NoExpiration`).
 The Options.MaxLen parameter will remove older stream entries to accommodate newer entries after the maximum number of entries is reached.
-
+The Options.Approx parameter provides better efficiency by providing almost exact trimming.
 #### Metadata
 
 The package defines a Metadata type as:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ stream.Add(ctx, Event{
 ```
 The Options.TTL parameter will evict stream entries after the specified duration has elapsed (or it can be set to `NoExpiration`).
 The Options.MaxLen parameter will remove older stream entries to accommodate newer entries after the maximum number of entries is reached.
-The Options.Approx parameter provides better efficiency by providing almost exact trimming.
+The Options.Approx parameter provides better efficiency by using almost exact trimming.
 #### Metadata
 
 The package defines a Metadata type as:


### PR DESCRIPTION
I would like to limit the number of messages stored in a stream.
This ensures that streams consume a fixed amount of storage and prevents piling up of messages.

There is already a TTL option.
But, in load scenarios the messages might still pile up within the TTL.