### PR TITLE
stream interface + satisfy consumer interface 

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -7,11 +7,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// Consumer is a generic consumer interface
-type Consumer[T any] interface {
-	Chan() <-chan Message[T]
-	Close()
-}
+var _ Consumer[any] = (*StreamConsumer[any])(nil)
 
 type StreamIDs = map[string]string
 
@@ -85,7 +81,7 @@ func (sc *StreamConsumer[T]) Chan() <-chan Message[T] {
 //
 // The StreamIds can be used to construct a new StreamConsumer that will
 // pick up where this left off.
-func (sc *StreamConsumer[T]) Close() StreamIDs {
+func (sc *StreamConsumer[T]) Close() any {
 	select {
 	case <-sc.ctx.Done():
 	default:

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -143,7 +143,7 @@ func TestConsumer_CloseGetSeenIDs(t *testing.T) {
 		<-cs.Chan()
 	}
 
-	seen := cs.Close()
+	seen := cs.Close().(StreamIDs)
 	assert.Equal(t, fmt.Sprintf("0-%v", consumeCount), seen["s1"])
 }
 
@@ -172,7 +172,7 @@ func TestConsumer_CancelContext(t *testing.T) {
 		}
 	}
 
-	seen := cs.Close()
+	seen := cs.Close().(StreamIDs)
 	assert.Equal(t, fmt.Sprintf("0-%v", consumeCount), seen["s1"])
 }
 

--- a/group_consumer.go
+++ b/group_consumer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+var _ (Consumer[any]) = (*GroupConsumer[any])(nil)
+
 // ErrAckBadRetVal is caused by XACK not accepting an request by returning 0.
 // This usually indicates that the id is wrong or the stream has no groups.
 var ErrAckBadRetVal = errors.New("XAck made no acknowledgement")
@@ -142,7 +144,7 @@ func (gc *GroupConsumer[T]) AwaitAcks() []Message[T] {
 // Close closes the consumer (if not already closed) and returns
 // a slice of unprocessed ack requests. An ack request in unprocessed if it
 // wasn't sent or its error wasn't consumed.
-func (gc *GroupConsumer[T]) Close() []InnerAck {
+func (gc *GroupConsumer[T]) Close() any {
 	select {
 	case <-gc.ctx.Done():
 	default:

--- a/group_consumer_test.go
+++ b/group_consumer_test.go
@@ -212,7 +212,7 @@ func TestGroupConsumer_AckErrors(t *testing.T) {
 	}
 
 	lastErrs := cs.AwaitAcks()
-	unseen := cs.Close()
+	unseen := cs.Close().([]InnerAck)
 	assert.NotZero(t, len(lastErrs)+len(unseen))
 	assert.Equal(t, readCount, ackErrors+len(unseen)+len(lastErrs))
 }
@@ -397,5 +397,5 @@ func TestGroupConsumer_ConcurrentRead(t *testing.T) {
 	assert.Greater(t, len(msgError), 1)
 	assert.Greater(t, len(msg), 1)
 	assert.Equal(t, len(msg)+len(msgError), 15)
-	assert.Equal(t, len(cs.Close())+len(msgList)+len(msg)+len(msgError), 101)
+	assert.Equal(t, len(cs.Close().([]InnerAck))+len(msgList)+len(msg)+len(msgError), 101)
 }

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,18 @@
+package gtrs
+
+import "context"
+
+// Stream represents a redis stream with messages of type T.
+type Stream[T any] interface {
+	Add(ctx context.Context, v T, idarg ...string) (string, error)
+	Key() string
+	Range(ctx context.Context, from, to string, count ...int64) ([]Message[T], error)
+	RevRange(ctx context.Context, from, to string, count ...int64) ([]Message[T], error)
+	Len(ctx context.Context) (int64, error)
+}
+
+// Consumer is a generic consumer interface
+type Consumer[T any] interface {
+	Chan() <-chan Message[T]
+	Close() any
+}


### PR DESCRIPTION
a few breaking changes here....

1. people who were using type `*Stream[T]` before should change to either `Stream[T]` or `*RedisStream[T]`
2. the two consumers now both properly implement the consumer interface, at the cost of making Close() return any and requiring the user to cast the type out.

@dranikpg did you know that neither consumer matched the consumer interface? im not sure if my solution here is good, it was just easy. 

perhaps its better to unite these two return types into a single return type that can be shared by the close method?

 